### PR TITLE
fix: post-PR#1 cleanup — fix tests, cache _available_browsers, sync version

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,7 +15,7 @@ class TestCliBasic:
     def test_version(self):
         result = runner.invoke(cli, ["--version"])
         assert result.exit_code == 0
-        assert "0.1.0" in result.output
+        assert "0.2.1" in result.output
 
     def test_help(self):
         result = runner.invoke(cli, ["--help"])

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -74,15 +74,25 @@ class TestCookiesToString:
 class TestGetCookies:
     def test_prefers_saved_cookies_by_default(self, monkeypatch):
         monkeypatch.setattr("xhs_cli.cookies.load_saved_cookies", lambda: {"a1": "saved"})
-        monkeypatch.setattr("xhs_cli.cookies.extract_browser_cookies", lambda source: {"a1": "fresh"})
+        monkeypatch.setattr(
+            "xhs_cli.cookies.extract_browser_cookies",
+            lambda source: ("chrome", {"a1": "fresh"}),
+        )
 
-        assert get_cookies("chrome") == {"a1": "saved"}
+        browser, cookies = get_cookies("chrome")
+        assert browser == "saved"
+        assert cookies == {"a1": "saved"}
 
     def test_force_refresh_bypasses_saved_cookies(self, monkeypatch):
         monkeypatch.setattr("xhs_cli.cookies.load_saved_cookies", lambda: {"a1": "saved"})
-        monkeypatch.setattr("xhs_cli.cookies.extract_browser_cookies", lambda source: {"a1": "fresh"})
+        monkeypatch.setattr(
+            "xhs_cli.cookies.extract_browser_cookies",
+            lambda source: ("chrome", {"a1": "fresh"}),
+        )
         saved = []
         monkeypatch.setattr("xhs_cli.cookies.save_cookies", lambda cookies: saved.append(cookies))
 
-        assert get_cookies("chrome", force_refresh=True) == {"a1": "fresh"}
+        browser, cookies = get_cookies("chrome", force_refresh=True)
+        assert browser == "chrome"
+        assert cookies == {"a1": "fresh"}
         assert saved == [{"a1": "fresh"}]

--- a/xhs_cli/__init__.py
+++ b/xhs_cli/__init__.py
@@ -1,3 +1,3 @@
 """xiaohongshu-cli: Xiaohongshu CLI via reverse-engineered API."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.1"

--- a/xhs_cli/cookies.py
+++ b/xhs_cli/cookies.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 import json
 import logging
 import subprocess
@@ -63,13 +64,14 @@ def clear_cookies() -> None:
         logger.debug("Cleared cookies from %s", cookie_path)
 
 
-def _available_browsers() -> list[str]:
-    """List all browser names supported by browser_cookie3."""
+@functools.lru_cache(maxsize=1)
+def _available_browsers() -> tuple[str, ...]:
+    """List all browser names supported by browser_cookie3 (cached)."""
     import inspect
 
     import browser_cookie3 as bc3
 
-    return sorted(
+    return tuple(sorted(
         name
         for name in dir(bc3)
         if not name.startswith("_")
@@ -77,7 +79,7 @@ def _available_browsers() -> list[str]:
         and callable(getattr(bc3, name))
         and hasattr(getattr(bc3, name), "__code__")
         and "domain_name" in inspect.signature(getattr(bc3, name)).parameters
-    )
+    ))
 
 
 def _get_browser_loader(source: str):


### PR DESCRIPTION
## Summary

PR #1（自动检测浏览器提取 Cookie）合并后遗留的修复：

### 修复内容

1. **测试修复** — `test_cookies.py` 适配 `get_cookies()` / `extract_browser_cookies()` 新的 `tuple[str, dict]` 返回类型
2. **版本号同步** — `__init__.py` 的 `__version__` 从 `0.1.0` 更新为 `0.2.1`，与 `pyproject.toml` 一致
3. **版本测试修复** — `test_cli.py` 中版本断言更新为 `0.2.1`
4. **性能优化** — `_available_browsers()` 添加 `@lru_cache`，避免每次 auto-detect 都重复执行 `inspect.signature`

### 测试

```
27 passed in 0.24s
```