### PR TITLE
fix: normalize comment reply counts in rich output

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -165,3 +165,25 @@ class TestCliBasic:
         payload = yaml.safe_load(result.output)
         assert payload["ok"] is False
         assert payload["error"]["code"] == "unsupported_operation"
+
+    def test_comments_rich_output_handles_string_reply_counts(self, monkeypatch):
+        monkeypatch.setenv("OUTPUT", "rich")
+        monkeypatch.setattr(
+            "xhs_cli.commands.reading.run_client_action",
+            lambda ctx, action: {
+                "comments": [
+                    {
+                        "user_info": {"nickname": "tester"},
+                        "content": "hello",
+                        "like_count": "12",
+                        "sub_comment_count": "2",
+                    }
+                ]
+            },
+        )
+
+        result = runner.invoke(cli, ["comments", "note-123"])
+
+        assert result.exit_code == 0
+        assert "tester" in result.output
+        assert "2 replies" in result.output

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1,6 +1,6 @@
 """Unit tests for formatter (no network required)."""
 
-from xhs_cli.formatter import extract_note_id, format_count
+from xhs_cli.formatter import coerce_int, extract_note_id, format_count
 
 
 class TestFormatCount:
@@ -18,6 +18,17 @@ class TestFormatCount:
 
     def test_string_large(self):
         assert format_count("50000") == "5.0万"
+
+
+class TestCoerceInt:
+    def test_int_input(self):
+        assert coerce_int(3) == 3
+
+    def test_string_input(self):
+        assert coerce_int("42") == 42
+
+    def test_invalid_string_falls_back(self):
+        assert coerce_int("10+") == 0
 
 
 class TestExtractNoteId:

--- a/xhs_cli/formatter.py
+++ b/xhs_cli/formatter.py
@@ -145,6 +145,20 @@ def print_info(message: str) -> None:
     console.print(f"[dim]ℹ[/dim] {message}")
 
 
+def coerce_int(value: Any, default: int = 0) -> int:
+    """Best-effort integer coercion for reverse-engineered API fields."""
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value.strip())
+        except ValueError:
+            return default
+    return default
+
+
 def format_count(n: int | str) -> str:
     """Format number for display (e.g., 12345 → 1.2万)."""
     if isinstance(n, str):
@@ -327,8 +341,8 @@ def render_comments(data: dict[str, Any]) -> None:
         user = comment.get("user_info", {})
         nickname = user.get("nickname", "Unknown")
         content = comment.get("content", "")
-        like_count = comment.get("like_count", "0")
-        sub_comment_count = comment.get("sub_comment_count", 0)
+        like_count = format_count(comment.get("like_count", "0"))
+        sub_comment_count = coerce_int(comment.get("sub_comment_count", 0))
 
         header = f"[bold]{nickname}[/bold]  [dim]❤️ {like_count}[/dim]"
         if sub_comment_count > 0:


### PR DESCRIPTION
## Summary
- normalize reverse-engineered comment reply counts before Rich rendering
- format comment like counts consistently in the comments view
- add regression tests for formatter coercion and Rich CLI comments output

## Root Cause
The comments endpoint returns count-like fields such as `sub_comment_count` as strings (for example `"0"` and `"3"`). The Rich renderer compared that raw value against integer `0`, which raised `TypeError: '>' not supported between instances of 'str' and 'int'`.

## Validation
- `uv run pytest tests/test_formatter.py tests/test_cli.py -q`
- `uv run pytest -q`
- `env OUTPUT=rich uv run xhs comments 'https://www.xiaohongshu.com/explore/69ae6c6600000000150389a1?xsec_token=ABU_4MCUzjpLDsiX7h5EJiNHSxoMRI-ebGa_VLyCoKqno=&xsec_source=pc_feed'`
- `env OUTPUT=rich uv run xhs comments 'https://www.xiaohongshu.com/explore/69ae6c6600000000150389a1?xsec_token=ABU_4MCUzjpLDsiX7h5EJiNHSxoMRI-ebGa_VLyCoKqno=&xsec_source=pc_feed' --all`

Closes #8
