### PR TITLE
fix: add ensure_ascii=False to POST body to match signing library

### DIFF
--- a/xhs_cli/client.py
+++ b/xhs_cli/client.py
@@ -212,7 +212,7 @@ class XhsClient(
         if header_overrides:
             headers.update(header_overrides)
         logger.debug("POST %s", url)
-        resp = self._request_with_retry("POST", url, headers=headers, content=json.dumps(data, separators=(",", ":")))
+        resp = self._request_with_retry("POST", url, headers=headers, content=json.dumps(data, separators=(",", ":"), ensure_ascii=False))
         return self._handle_response(resp)
 
     def _creator_host(self, uri: str) -> str:
@@ -250,5 +250,5 @@ class XhsClient(
             "referer": f"{CREATOR_HOST}/",
         }
         logger.debug("Creator POST %s", url)
-        resp = self._request_with_retry("POST", url, headers=headers, content=json.dumps(data, separators=(",", ":")))
+        resp = self._request_with_retry("POST", url, headers=headers, content=json.dumps(data, separators=(",", ":"), ensure_ascii=False))
         return self._handle_response(resp)


### PR DESCRIPTION
## Root Cause

Closes #18

The `xhshow` signing library computes the content string for POST requests using:
```python
json.dumps(payload, separators=(',', ':'), ensure_ascii=False)
```

But `_main_api_post` (and `_creator_post`) were sending the request body with:
```python
json.dumps(data, separators=(',', ':'))  # ensure_ascii=True by default
```

When the payload contains non-ASCII characters (e.g. Chinese text in a comment or note body), the two serializations differ:
- Signed over: `{"content":"测试"}`
- Body sent:   `{"content":"\u6d4b\u8bd5"}`

The XHS server recomputes the signature from the actual request body and rejects it with **HTTP 406** because the hashes don't match.

## Fix

Add `ensure_ascii=False` to both POST body serializations to match `xhshow`'s signing behavior.

```python
# before
content=json.dumps(data, separators=(',', ':'))
# after
content=json.dumps(data, separators=(',', ':'), ensure_ascii=False)
```

## Verification

Tested locally on macOS arm64, Python 3.14, with a real XHS account:
- `xhs comment <id> -c "测试"` → **HTTP 200 OK** ✅
- `xhs post` with Chinese title/body → **HTTP 200 OK** ✅

Note: pure ASCII payloads were unaffected by this bug (no difference between `ensure_ascii=True/False` for ASCII-only content), which explains why some operations appeared to work while others failed.