### PR TITLE
Fix QR login failure from missing Camoufox addon manifest

### DIFF
--- a/tests/test_qr_login.py
+++ b/tests/test_qr_login.py
@@ -4,7 +4,12 @@ import pytest
 
 from xhs_cli.command_normalizers import normalize_xhs_user_payload
 from xhs_cli.exceptions import XhsApiError
-from xhs_cli.qr_login import BrowserQrLoginUnavailable, _normalize_browser_cookies, qrcode_login
+from xhs_cli.qr_login import (
+    BrowserQrLoginUnavailable,
+    _camoufox_launch_options,
+    _normalize_browser_cookies,
+    qrcode_login,
+)
 
 
 class _FakeQrClient:
@@ -217,6 +222,15 @@ def test_qrcode_login_falls_back_when_browser_backend_unavailable(monkeypatch):
         "webId": "webid-http",
         "web_session": "http-session",
     }
+
+
+def test_browser_assisted_login_excludes_default_addons():
+    from camoufox import DefaultAddons
+
+    options = _camoufox_launch_options()
+
+    assert options["headless"] is False
+    assert options["exclude_addons"] == [DefaultAddons.UBO]
 
 
 def test_normalize_browser_cookies_uses_allowlist():

--- a/xhs_cli/qr_login.py
+++ b/xhs_cli/qr_login.py
@@ -337,6 +337,16 @@ def _ensure_camoufox_ready() -> None:
         )
 
 
+def _camoufox_launch_options() -> dict[str, Any]:
+    """Return Camoufox launch options for browser-assisted QR login."""
+    from camoufox import DefaultAddons
+
+    return {
+        "headless": False,
+        "exclude_addons": [DefaultAddons.UBO],
+    }
+
+
 def _browser_assisted_qrcode_login(
     *,
     on_status: callable[[str], None] | None = None,
@@ -347,6 +357,7 @@ def _browser_assisted_qrcode_login(
 
     try:
         from camoufox.sync_api import Camoufox
+        launch_options = _camoufox_launch_options()
     except ImportError as exc:
         raise BrowserQrLoginUnavailable(
             "Camoufox sync API is unavailable in the current environment."
@@ -356,7 +367,7 @@ def _browser_assisted_qrcode_login(
 
     _emit_status(on_status, "🔑 Starting browser-assisted QR login...")
 
-    with Camoufox(headless=False) as browser:
+    with Camoufox(**launch_options) as browser:
         page = browser.new_page()
 
         def _handle_response(response) -> None:


### PR DESCRIPTION
## Summary

Fixes browser-assisted QR login failing during Camoufox startup when the default UBO addon cache exists but is incomplete and lacks manifest.json.

## Root Cause

Camoufox adds its default UBO addon during launch. If the addon directory already exists but extraction or download previously left it empty or incomplete, Camoufox skips re-downloading it and later raises InvalidAddonPath because manifest.json is missing.

## Changes

- Add a small helper for browser-assisted Camoufox launch options.
- Exclude Camoufox default UBO addon for QR login because the login flow does not depend on it.
- Add a regression test asserting the QR login launch options exclude the default addon.

## Validation

- uv run pytest
- uv run ruff check .
- uvx pip-audit