### PR TITLE
security: harden credential handling and write safeguards

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -101,6 +101,8 @@ Payloads live under `.data`.
 
 ### Interactions (Write)
 
+Before running any command that changes account state, show the intended action and target, then obtain the user's explicit confirmation. A general request to browse, research, or analyze is not authorization to write. Never use `-y` without that confirmation. This applies to likes, favorites, comments, replies, follows, posts, and deletions, including undo/unfollow operations.
+
 | Command | Description | Example |
 |---------|-------------|---------|
 | `xhs like <id_or_url_or_index>` | Like a note | `xhs like 1` / `xhs like abc123` |
@@ -143,6 +145,7 @@ Payloads live under `.data`.
 ```bash
 NOTE_ID=$(xhs search "美食推荐" --json | jq -r '.data.items[0].id')
 xhs read "$NOTE_ID" --json | jq '.data'
+# Run only after the user explicitly confirms this like:
 xhs like "$NOTE_ID"
 ```
 
@@ -156,6 +159,7 @@ xhs hot -c food --json | jq '.data.items[:5] | .[].note_card | {title, likes: .i
 
 ```bash
 xhs user 5f2e123 --json | jq '.data.basic_info | {nickname, user_id}'
+# Run only after the user explicitly confirms this follow:
 xhs follow 5f2e123
 ```
 
@@ -185,6 +189,7 @@ xhs feed --yaml
 xhs search "旅行"
 xhs read 1
 xhs comments 1
+# Run each command below only after the user explicitly confirms its exact action:
 xhs like 1
 xhs favorite 1
 xhs comment 1 -c "收藏了"
@@ -245,6 +250,7 @@ Structured error codes returned in the `error.code` field:
 
 ## Safety Notes
 
+- Obtain explicit user confirmation immediately before every account write operation: like/unlike, favorite/unfavorite, comment/reply/delete-comment, follow/unfollow, post, or delete.
 - Do not ask users to share raw cookie values in chat logs.
 - Prefer local browser cookie extraction over manual secret copy/paste.
 - If auth fails, ask the user to re-login via `xhs login`.

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -51,6 +51,21 @@ class TestSaveCookies:
         stat = cookie_file.stat()
         assert stat.st_mode & 0o777 == 0o600
 
+    def test_failed_replace_preserves_existing_file(self, tmp_config_dir, monkeypatch):
+        cookie_file = tmp_config_dir / "cookies.json"
+        cookie_file.write_text('{"a1":"existing"}')
+
+        def fail_replace(*_):
+            raise OSError
+
+        monkeypatch.setattr("xhs_cli.cookies.os.replace", fail_replace)
+
+        with pytest.raises(OSError):
+            save_cookies({"a1": "replacement"})
+
+        assert cookie_file.read_text() == '{"a1":"existing"}'
+        assert list(tmp_config_dir.glob(".cookies.json.*")) == []
+
 
 class TestLoadSavedCookies:
     def test_no_file(self, tmp_config_dir):

--- a/xhs_cli/client_mixins.py
+++ b/xhs_cli/client_mixins.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from .constants import CREATOR_HOST, HOME_URL, UPLOAD_HOST, USER_AGENT
 from .cookies import (
+    _write_secure_json,
     cache_note_context,
     cookies_to_string,
     get_cached_note_context,
@@ -117,8 +118,7 @@ def _save_search_session_cache(path: Path) -> None:
         )
         for key, value in _SEARCH_SESSION_CACHE.items()
     )
-    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False))
-    path.chmod(0o600)
+    _write_secure_json(path, payload, ensure_ascii=False)
 
 
 def _ensure_search_session_cache_loaded() -> None:

--- a/xhs_cli/cookies.py
+++ b/xhs_cli/cookies.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import functools
 import json
 import logging
+import os
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 from collections import OrderedDict
@@ -64,12 +66,32 @@ def load_saved_cookies() -> dict[str, str] | None:
     return None
 
 
+def _write_secure_json(
+    path: Path,
+    payload: Any,
+    *,
+    durable: bool = False,
+    ensure_ascii: bool = True,
+) -> None:
+    """Atomically write JSON through a mode-0600 temporary file."""
+    fd, temp_path = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w") as temp_file:
+            json.dump(payload, temp_file, indent=2, ensure_ascii=ensure_ascii)
+            if durable:
+                temp_file.flush()
+                os.fsync(temp_file.fileno())
+        os.replace(temp_path, path)
+    except BaseException:
+        Path(temp_path).unlink(missing_ok=True)
+        raise
+
+
 def save_cookies(cookies: dict[str, str]) -> None:
     """Save cookies to local storage with restricted permissions and TTL timestamp."""
     cookie_path = get_cookie_path()
     payload = {**cookies, "saved_at": time.time()}
-    cookie_path.write_text(json.dumps(payload, indent=2))
-    cookie_path.chmod(0o600)
+    _write_secure_json(cookie_path, payload, durable=True)
     logger.debug("Saved cookies to %s", cookie_path)
 
 
@@ -174,8 +196,7 @@ def save_token_cache(cache: dict[str, dict[str, Any]]) -> None:
     ))
 
     with _TOKEN_CACHE_LOCK:
-        cache_path.write_text(json.dumps(normalized, indent=2))
-        cache_path.chmod(0o600)
+        _write_secure_json(cache_path, normalized)
         _TOKEN_CACHE_MEMORY = normalized
         _TOKEN_CACHE_PATH = cache_path
 
@@ -268,8 +289,7 @@ def save_note_index(items: list[dict[str, str]]) -> None:
         for entry in (_normalize_index_entry(item) for item in items)
         if entry
     ]
-    path.write_text(json.dumps(normalized, indent=2, ensure_ascii=False))
-    path.chmod(0o600)
+    _write_secure_json(path, normalized, ensure_ascii=False)
     logger.debug("Saved note index with %d entries", len(normalized))
 
 

--- a/xhs_cli/qr_login.py
+++ b/xhs_cli/qr_login.py
@@ -226,16 +226,11 @@ def _complete_confirmed_session(
             )
         logger.debug(
             "QR post-confirm completion attempt=%d confirmed_user_id=%s "
-            "completion_user_id=%s self_info_user_id=%s cookies=%s data=%s",
+            "completion_user_id=%s self_info_user_id=%s",
             attempt + 1,
             confirmed_user_id,
             completed_user_id,
             self_info_user_id,
-            {
-                "web_session": client.cookies.get("web_session"),
-                "web_session_sec": client.cookies.get("web_session_sec"),
-            },
-            completion_data,
         )
         if completed_user_id and completed_user_id == confirmed_user_id:
             return completion_data
@@ -248,8 +243,7 @@ def _complete_confirmed_session(
         "QR login confirmed, but completion never returned the confirmed user session. "
         f"expected={confirmed_user_id} "
         f"completion_user={_resolved_user_id(last_data) or 'unknown'} "
-        f"self_info_user={last_self_info_user_id or 'unknown'} "
-        f"completion_data={last_data}"
+        f"self_info_user={last_self_info_user_id or 'unknown'}"
     )
 
 
@@ -431,7 +425,7 @@ def _browser_assisted_qrcode_login(
         if missing:
             raise XhsApiError(
                 "Browser-assisted QR login succeeded, but exported cookies were incomplete: "
-                f"missing={', '.join(missing)} completion_data={completion_data}"
+                f"missing={', '.join(missing)}"
             )
 
         save_cookies(cookies)
@@ -459,11 +453,7 @@ def _http_qrcode_login(
         try:
             activate_data = client.login_activate()
             _apply_session_cookies(client, activate_data)
-            guest_session = activate_data.get("session", "")
-            logger.debug(
-                "Initial activate: session=%s user_id=%s",
-                guest_session, activate_data.get("user_id"),
-            )
+            logger.debug("Initial activate: user_id=%s", activate_data.get("user_id"))
         except Exception as exc:
             logger.debug("Initial activate failed (non-fatal): %s", exc)
 
@@ -471,8 +461,6 @@ def _http_qrcode_login(
         qr_id = qr_data["qr_id"]
         code = qr_data["code"]
         qr_url = qr_data["url"]
-
-        logger.debug("QR created: qr_id=%s, code=%s", qr_id, code)
 
         _emit_status(on_status, "\n📱 Scan the QR code below with the Xiaohongshu app:\n")
         if not _display_qr_in_terminal(qr_url):
@@ -499,7 +487,7 @@ def _http_qrcode_login(
                 consecutive_errors = 0
 
             code_status = status_data.get("codeStatus", -1)
-            logger.debug("QR poll: codeStatus=%s data=%s", code_status, status_data)
+            logger.debug("QR poll: codeStatus=%s", code_status)
 
             if code_status != last_status:
                 last_status = code_status


### PR DESCRIPTION
## What changed

- write cookies, token caches, note indexes, and search-session caches atomically through mode-0600 temporary files
- preserve an existing credential file if replacement fails
- remove session cookies, QR codes, and API payloads from QR-login debug logs and errors
- require explicit user confirmation before every account-changing command in the agent skill

## Why

Credential files were written in place and restricted only after the write completed, creating a brief permissive-file window and allowing interruption to truncate existing state. QR-login diagnostics could also expose session material, while the skill examples did not consistently gate authenticated mutations.

## Impact

Local credential state is replaced atomically with restrictive permissions, failed replacement no longer destroys an existing cookie file, diagnostics avoid secret-bearing values, and agent-driven writes require an explicit user decision.

## Validation

- `uv run pytest tests/test_cookies.py` — 18 passed
- `uv run pytest` — 115 passed, 27 skipped
- `uv run ruff check .`
- `git diff --check`
