### PR TITLE
feat: add privacy-safe diagnostics and support bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ xhs status                            # Check login status
 xhs whoami                            # Detailed profile (fans, likes, etc)
 xhs whoami --json                     # Structured JSON envelope
 xhs logout                            # Clear saved cookies
+xhs doctor --json                     # Privacy-safe local diagnostics
+xhs doctor --network --json           # Also validate the API with saved cookies
+xhs support-bundle report.json        # Write a redacted, mode-0600 support report
 
 # ─── Search ───────────────────────────────────────
 xhs search "美食"                      # Search notes

--- a/SKILL.md
+++ b/SKILL.md
@@ -134,6 +134,8 @@ Payloads live under `.data`.
 | `xhs login --qrcode` | Browser-assisted QR login — terminal QR output, browser completes login |
 | `xhs status` | Check authentication status |
 | `xhs logout` | Clear cached cookies |
+| `xhs doctor --json` | Diagnose local auth, signing, browser support, and compatibility without exposing secrets |
+| `xhs support-bundle report.json` | Write a redacted diagnostic report for bug reports |
 | `xhs whoami` | Show current user profile |
 
 ## Agent Workflow Examples

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,39 @@
+"""Tests for privacy-safe diagnostics."""
+
+import json
+
+from click.testing import CliRunner
+
+from xhs_cli.cli import cli
+from xhs_cli.commands import diagnostics
+
+runner = CliRunner()
+
+
+def test_doctor_json_never_contains_credentials(monkeypatch):
+    secret = "secret-cookie-value"
+    monkeypatch.setattr(diagnostics, "load_saved_cookies", lambda: {"a1": secret})
+    monkeypatch.setattr(diagnostics, "_cookie_check", lambda: {"status": "ok", "has_required_cookie": True})
+    monkeypatch.setattr(diagnostics, "_available_browsers", lambda: ("chrome",))
+
+    result = runner.invoke(cli, ["doctor", "--json"])
+
+    assert result.exit_code == 0
+    assert secret not in result.output
+    assert json.loads(result.output)["data"]["checks"]["api"]["status"] == "skipped"
+
+
+def test_support_bundle_is_redacted_and_private(monkeypatch, tmp_path):
+    secret = "secret-cookie-value"
+    monkeypatch.setattr(diagnostics, "load_saved_cookies", lambda: {"a1": secret})
+    monkeypatch.setattr(diagnostics, "_cookie_check", lambda: {"status": "ok", "has_required_cookie": True})
+    monkeypatch.setattr(diagnostics, "_available_browsers", lambda: ("chrome",))
+    output = tmp_path / "bundle.json"
+
+    result = runner.invoke(cli, ["support-bundle", str(output), "--json"])
+
+    assert result.exit_code == 0
+    content = output.read_text()
+    assert secret not in content
+    assert output.stat().st_mode & 0o777 == 0o600
+    assert json.loads(content)["data"]["privacy"]["contains_cookie_values"] is False

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -23,6 +23,37 @@ def test_doctor_json_never_contains_credentials(monkeypatch):
     assert json.loads(result.output)["data"]["checks"]["api"]["status"] == "skipped"
 
 
+def test_network_check_sends_only_transport_cookies(monkeypatch):
+    captured = {}
+
+    class FakeClient:
+        def __init__(self, cookies):
+            captured.update(cookies)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+        def get_self_info(self):
+            return {"nickname": "tester"}
+
+    monkeypatch.setattr(
+        diagnostics,
+        "load_saved_cookies",
+        lambda: {"a1": "secret", "web_session": "session", "saved_at": 123.0, "nickname": "local"},
+    )
+    monkeypatch.setattr(diagnostics, "XhsClient", FakeClient)
+    monkeypatch.setattr(diagnostics, "_cookie_check", lambda: {"status": "ok"})
+    monkeypatch.setattr(diagnostics, "_available_browsers", lambda: ())
+
+    report = diagnostics.collect_diagnostics(check_api=True)
+
+    assert report["checks"]["api"]["status"] == "ok"
+    assert captured == {"a1": "secret", "web_session": "session"}
+
+
 def test_support_bundle_is_redacted_and_private(monkeypatch, tmp_path):
     secret = "secret-cookie-value"
     monkeypatch.setattr(diagnostics, "load_saved_cookies", lambda: {"a1": secret})

--- a/xhs_cli/cli.py
+++ b/xhs_cli/cli.py
@@ -31,7 +31,7 @@ import sys
 import click
 
 from . import __version__
-from .commands import auth, creator, interactions, notifications, reading, social
+from .commands import auth, creator, diagnostics, interactions, notifications, reading, social
 
 
 def _fix_windows_encoding() -> None:
@@ -74,6 +74,8 @@ cli.add_command(auth.login)
 cli.add_command(auth.status)
 cli.add_command(auth.logout)
 cli.add_command(auth.whoami)
+cli.add_command(diagnostics.doctor)
+cli.add_command(diagnostics.support_bundle)
 
 # ─── Reading commands ────────────────────────────────────────────────────────
 

--- a/xhs_cli/commands/diagnostics.py
+++ b/xhs_cli/commands/diagnostics.py
@@ -1,0 +1,146 @@
+"""Privacy-safe environment diagnostics and support bundles."""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import stat
+import time
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from typing import Any
+
+import click
+
+from .. import __version__
+from ..client import XhsClient
+from ..constants import CONFIG_DIR_NAME, COOKIE_FILE
+from ..cookies import _available_browsers, load_saved_cookies
+from ..error_codes import error_code_for_exception
+from ..formatter import console, maybe_print_structured, print_success, success_payload
+from ..signing import sign_main_api
+from ._common import structured_output_options
+
+
+def _dependency_versions() -> dict[str, str]:
+    packages = ("httpx", "click", "browser-cookie3", "xhshow")
+    result = {}
+    for package in packages:
+        try:
+            result[package] = version(package)
+        except PackageNotFoundError:
+            result[package] = "missing"
+    return result
+
+
+def _cookie_check() -> dict[str, Any]:
+    path = Path.home() / CONFIG_DIR_NAME / COOKIE_FILE
+    result: dict[str, Any] = {"status": "missing", "exists": path.exists()}
+    if not path.exists():
+        return result
+
+    try:
+        payload = json.loads(path.read_text())
+        mode = stat.S_IMODE(path.stat().st_mode)
+        saved_at = payload.get("saved_at") if isinstance(payload, dict) else None
+        result.update({
+            "status": "ok" if isinstance(payload, dict) and bool(payload.get("a1")) else "invalid",
+            "valid_json": isinstance(payload, dict),
+            "has_required_cookie": isinstance(payload, dict) and bool(payload.get("a1")),
+            "permissions": oct(mode),
+            "permissions_restricted": mode & 0o077 == 0,
+            "age_days": round((time.time() - float(saved_at)) / 86400, 1) if saved_at else None,
+        })
+    except (OSError, ValueError, TypeError, json.JSONDecodeError) as exc:
+        result.update({"status": "invalid", "error_type": type(exc).__name__})
+    return result
+
+
+def _signing_check() -> dict[str, Any]:
+    try:
+        headers = sign_main_api("GET", "/api/sns/web/v2/user/me", {"a1": "0" * 52})
+        return {"status": "ok", "headers_generated": all(key in headers for key in ("x-s", "x-t"))}
+    except Exception as exc:
+        return {"status": "error", "error_type": type(exc).__name__}
+
+
+def collect_diagnostics(*, check_api: bool = False) -> dict[str, Any]:
+    """Collect diagnostics without returning secrets or user profile data."""
+    api: dict[str, Any] = {"status": "skipped", "reason": "use --network to check"}
+    if check_api:
+        cookies = load_saved_cookies()
+        if not cookies:
+            api = {"status": "skipped", "reason": "no saved credentials"}
+        else:
+            try:
+                with XhsClient(cookies) as client:
+                    client.get_self_info()
+                api = {"status": "ok"}
+            except Exception as exc:
+                api = {
+                    "status": "error",
+                    "error_code": error_code_for_exception(exc),
+                    "error_type": type(exc).__name__,
+                }
+
+    try:
+        browser_sources = list(_available_browsers())
+        browser_check = {"status": "ok", "supported_sources": browser_sources}
+    except Exception as exc:
+        browser_check = {"status": "error", "error_type": type(exc).__name__}
+
+    return {
+        "generated_at": int(time.time()),
+        "cli_version": __version__,
+        "runtime": {"python": platform.python_version(), "system": platform.system()},
+        "dependencies": _dependency_versions(),
+        "checks": {
+            "cookies": _cookie_check(),
+            "signing": _signing_check(),
+            "browser_cookie_sources": browser_check,
+            "api": api,
+        },
+        "privacy": {
+            "contains_cookie_values": False,
+            "contains_tokens": False,
+            "contains_user_profile": False,
+        },
+    }
+
+
+def _render_report(report: dict[str, Any]) -> None:
+    console.print(f"[bold]xiaohongshu-cli {report['cli_version']} diagnostics[/bold]")
+    for name, check in report["checks"].items():
+        status_value = check["status"]
+        marker = "[green]✓[/green]" if status_value == "ok" else "[yellow]•[/yellow]"
+        console.print(f"{marker} {name}: {status_value}")
+
+
+@click.command()
+@click.option("--network", is_flag=True, help="Validate the API with saved credentials.")
+@structured_output_options
+def doctor(network: bool, as_json: bool, as_yaml: bool):
+    """Diagnose local auth, signing, browser support, and API compatibility."""
+    report = collect_diagnostics(check_api=network)
+    if not maybe_print_structured(report, as_json=as_json, as_yaml=as_yaml):
+        _render_report(report)
+
+
+@click.command("support-bundle")
+@click.argument("output", type=click.Path(path_type=Path), default=Path("xhs-support-bundle.json"))
+@click.option("--network", is_flag=True, help="Validate the API with saved credentials.")
+@structured_output_options
+def support_bundle(output: Path, network: bool, as_json: bool, as_yaml: bool):
+    """Write a redacted diagnostic report for bug reports."""
+    report = success_payload(collect_diagnostics(check_api=network))
+    output.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(output, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as file:
+        json.dump(report, file, ensure_ascii=False, indent=2)
+        file.write("\n")
+    output.chmod(0o600)
+
+    result = {"path": str(output), "redacted": True}
+    if not maybe_print_structured(result, as_json=as_json, as_yaml=as_yaml):
+        print_success(f"Redacted support bundle written to {output}")

--- a/xhs_cli/commands/diagnostics.py
+++ b/xhs_cli/commands/diagnostics.py
@@ -41,7 +41,7 @@ def _cookie_check() -> dict[str, Any]:
         return result
 
     try:
-        payload = json.loads(path.read_text())
+        payload = json.loads(path.read_text(encoding="utf-8"))
         mode = stat.S_IMODE(path.stat().st_mode)
         saved_at = payload.get("saved_at") if isinstance(payload, dict) else None
         result.update({
@@ -73,6 +73,13 @@ def collect_diagnostics(*, check_api: bool = False) -> dict[str, Any]:
         if not cookies:
             api = {"status": "skipped", "reason": "no saved credentials"}
         else:
+            from ..qr_login import BROWSER_EXPORT_COOKIE_NAMES
+
+            cookies = {
+                name: value
+                for name, value in cookies.items()
+                if name in BROWSER_EXPORT_COOKIE_NAMES and isinstance(value, str)
+            }
             try:
                 with XhsClient(cookies) as client:
                     client.get_self_info()
@@ -136,7 +143,7 @@ def support_bundle(output: Path, network: bool, as_json: bool, as_yaml: bool):
     report = success_payload(collect_diagnostics(check_api=network))
     output.parent.mkdir(parents=True, exist_ok=True)
     fd = os.open(output, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-    with os.fdopen(fd, "w") as file:
+    with os.fdopen(fd, "w", encoding="utf-8") as file:
         json.dump(report, file, ensure_ascii=False, indent=2)
         file.write("\n")
     output.chmod(0o600)


### PR DESCRIPTION
## What changed

- add `xhs doctor --json` for saved-login, cookie-file, signing, browser-source, runtime, and dependency diagnostics
- add explicit `xhs doctor --network --json` API compatibility checking
- add `xhs support-bundle [OUTPUT]` for a redacted mode-`0600` report
- use UTF-8 for diagnostic file reads and writes
- allowlist transport cookies before the optional network check

## Privacy and safety

Reports never include cookie values, tokens, user profiles, absolute config paths, or raw exception messages. The opt-in network check sends only recognized Xiaohongshu browser cookies; local fields such as `saved_at` or profile labels are removed.

## Why

Reverse-engineered API failures are often caused by stale credentials, browser integration, signing dependencies, or upstream API drift. These commands provide a reproducible diagnostic path without encouraging users to paste credentials into bug reports.

## Validation

- `uv run ruff check .`
- diagnostics tests: 3 passed
- remaining offline suite: 115 passed, 27 skipped, 13 deselected; two pre-existing cache-isolation tests are fixed in PR #76
- `uv build`
- `git diff --check`