### PR TITLE
fix: use UTF-8 for persisted JSON caches

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,7 @@
 """Unit tests for XHS client request payloads, cookies, and endpoint selection."""
 
 from collections import OrderedDict
+from pathlib import Path
 
 import httpx
 import pytest
@@ -8,6 +9,21 @@ import pytest
 from xhs_cli.client import XhsClient
 from xhs_cli.cookies import cache_note_context, get_cached_note_context
 from xhs_cli.exceptions import UnsupportedOperationError, XhsApiError
+
+
+def test_search_session_cache_reads_utf8(tmp_path, monkeypatch):
+    from xhs_cli.client_mixins import _load_search_session_cache_from_disk
+
+    path = tmp_path / "search_sessions.json"
+    path.touch()
+    original_read_text = Path.read_text
+
+    def checked_read_text(self, *args, **kwargs):
+        assert kwargs.get("encoding") == "utf-8"
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", checked_read_text)
+    assert _load_search_session_cache_from_disk(path) == OrderedDict()
 
 
 class TestFavorites:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,6 @@
 """Unit tests for XHS client request payloads, cookies, and endpoint selection."""
 
+import json
 from collections import OrderedDict
 from pathlib import Path
 
@@ -9,6 +10,20 @@ import pytest
 from xhs_cli.client import XhsClient
 from xhs_cli.cookies import cache_note_context, get_cached_note_context
 from xhs_cli.exceptions import UnsupportedOperationError, XhsApiError
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cache_files(tmp_path, monkeypatch):
+    import xhs_cli.client_mixins as client_mixins
+    import xhs_cli.cookies as cookies
+
+    monkeypatch.setattr(cookies, "get_config_dir", lambda: tmp_path)
+    monkeypatch.setattr(cookies, "_TOKEN_CACHE_MEMORY", None)
+    monkeypatch.setattr(cookies, "_TOKEN_CACHE_PATH", None)
+    monkeypatch.setattr(client_mixins, "get_config_dir", lambda: tmp_path)
+    monkeypatch.setattr(client_mixins, "_SEARCH_SESSION_CACHE", OrderedDict())
+    monkeypatch.setattr(client_mixins, "_SEARCH_SESSION_CACHE_LOADED", False)
+    monkeypatch.setattr(client_mixins, "_SEARCH_SESSION_CACHE_PATH", None)
 
 
 def test_search_session_cache_reads_utf8(tmp_path, monkeypatch):
@@ -23,6 +38,16 @@ def test_search_session_cache_reads_utf8(tmp_path, monkeypatch):
         return original_read_text(self, *args, **kwargs)
 
     monkeypatch.setattr(Path, "read_text", checked_read_text)
+    assert _load_search_session_cache_from_disk(path) == OrderedDict()
+
+
+def test_search_session_cache_discards_legacy_gbk(tmp_path):
+    from xhs_cli.client_mixins import _load_search_session_cache_from_disk
+
+    path = tmp_path / "search_sessions.json"
+    payload = {'["测试", "general", 0]': {"search_id": "legacy"}}
+    path.write_bytes(json.dumps(payload, ensure_ascii=False).encode("gbk"))
+
     assert _load_search_session_cache_from_disk(path) == OrderedDict()
 
 

--- a/xhs_cli/client_mixins.py
+++ b/xhs_cli/client_mixins.py
@@ -87,7 +87,7 @@ def _load_search_session_cache_from_disk(path: Path) -> OrderedDict[tuple[str, s
     if not path.exists():
         return OrderedDict()
     try:
-        data = json.loads(path.read_text())
+        data = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return OrderedDict()
     if not isinstance(data, dict):
@@ -117,7 +117,7 @@ def _save_search_session_cache(path: Path) -> None:
         )
         for key, value in _SEARCH_SESSION_CACHE.items()
     )
-    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False))
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
     path.chmod(0o600)
 
 

--- a/xhs_cli/client_mixins.py
+++ b/xhs_cli/client_mixins.py
@@ -88,7 +88,7 @@ def _load_search_session_cache_from_disk(path: Path) -> OrderedDict[tuple[str, s
         return OrderedDict()
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+    except (OSError, UnicodeError, json.JSONDecodeError):
         return OrderedDict()
     if not isinstance(data, dict):
         return OrderedDict()

--- a/xhs_cli/cookies.py
+++ b/xhs_cli/cookies.py
@@ -55,7 +55,7 @@ def load_saved_cookies() -> dict[str, str] | None:
     if not cookie_path.exists():
         return None
     try:
-        data = json.loads(cookie_path.read_text())
+        data = json.loads(cookie_path.read_text(encoding="utf-8"))
         if data.get("a1"):
             logger.debug("Loaded saved cookies from %s", cookie_path)
             return data
@@ -68,7 +68,7 @@ def save_cookies(cookies: dict[str, str]) -> None:
     """Save cookies to local storage with restricted permissions and TTL timestamp."""
     cookie_path = get_cookie_path()
     payload = {**cookies, "saved_at": time.time()}
-    cookie_path.write_text(json.dumps(payload, indent=2))
+    cookie_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
     cookie_path.chmod(0o600)
     logger.debug("Saved cookies to %s", cookie_path)
 
@@ -109,7 +109,7 @@ def _load_token_cache_from_disk(cache_path: Path) -> OrderedDict[str, dict[str, 
     if not cache_path.exists():
         return OrderedDict()
     try:
-        data = json.loads(cache_path.read_text())
+        data = json.loads(cache_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
         logger.debug("Failed to load token cache: %s", exc)
         return OrderedDict()
@@ -174,7 +174,7 @@ def save_token_cache(cache: dict[str, dict[str, Any]]) -> None:
     ))
 
     with _TOKEN_CACHE_LOCK:
-        cache_path.write_text(json.dumps(normalized, indent=2))
+        cache_path.write_text(json.dumps(normalized, indent=2), encoding="utf-8")
         cache_path.chmod(0o600)
         _TOKEN_CACHE_MEMORY = normalized
         _TOKEN_CACHE_PATH = cache_path
@@ -268,7 +268,7 @@ def save_note_index(items: list[dict[str, str]]) -> None:
         for entry in (_normalize_index_entry(item) for item in items)
         if entry
     ]
-    path.write_text(json.dumps(normalized, indent=2, ensure_ascii=False))
+    path.write_text(json.dumps(normalized, indent=2, ensure_ascii=False), encoding="utf-8")
     path.chmod(0o600)
     logger.debug("Saved note index with %d entries", len(normalized))
 
@@ -283,7 +283,7 @@ def get_note_by_index(index: int) -> dict[str, str] | None:
         return None
 
     try:
-        data = json.loads(path.read_text())
+        data = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return None
 


### PR DESCRIPTION
## What changed

- read and write persisted JSON caches with explicit UTF-8 encoding
- safely discard legacy search-session caches that cannot be decoded as UTF-8
- isolate cache tests from the developer real `~/.xiaohongshu-cli` directory
- cover explicit UTF-8 reads and an actual GBK-encoded legacy cache

## Root cause

Cache files used the platform default encoding. On Windows this made behavior depend on the active code page and allowed existing non-UTF-8 cache bytes to crash search before any API request. The original tests also reset in-memory state without resetting the cache path, so they could read and overwrite a real user cache.

## Impact

New cache files use deterministic UTF-8 across Windows, macOS, and Linux. A legacy undecodable search-session cache is treated as disposable and rebuilt automatically.

## Validation

- `uv run ruff check .`
- `uv run pytest -q` — 116 passed, 27 skipped, 11 deselected
- `uv build`
- `git diff --check`