### PR TITLE
feat: add agent-friendly note hydration command

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ xhs topics "美食"                      # Search hashtags/topics
 # ─── Reading ──────────────────────────────────────
 xhs read 1                             # Read the 1st result from the last list command
 xhs read <note_id>                     # Read a note (API only)
+xhs hydrate 1 --yaml                   # Normalized note + bounded comment sample for agents
 xhs read "https://www.xiaohongshu.com/explore/xxx?xsec_token=yyy"  # Read by URL (uses URL token)
 xhs comments 1                         # Read comments for the 1st result from the last list command
 xhs comments "<url>"                   # View comments — paste URL to cache/reuse xsec_token
@@ -374,6 +375,7 @@ xhs topics "美食"                      # 搜索话题
 # 阅读
 xhs read 1                             # 阅读最近一次列表里的第 1 条笔记
 xhs read <note_id>                     # 阅读笔记（仅走 API）
+xhs hydrate 1 --yaml                   # 面向 Agent 的标准化笔记与有限评论样本
 xhs read "https://...?xsec_token=..."  # 粘贴网页 URL 直接阅读（使用 URL token）
 xhs comments 1                         # 查看最近一次列表里的第 1 条笔记评论
 xhs comments "<url>"                   # 查看评论 — 粘贴 URL 以缓存/复用 xsec_token

--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -25,6 +25,45 @@ error:
 - `--yaml` and `--json` both use this envelope
 - non-TTY stdout defaults to YAML
 - reading and search commands return their payload under `data`
+- `hydrate` returns normalized `data.note`, a bounded `data.comments` sample,
+  and `data.warnings` for recoverable comment-fetch failures
 - `status` returns `data.authenticated` plus `data.user`
 - `whoami` returns `data.user`
 - common `error.code` values include `not_authenticated`, `verification_required`, `ip_blocked`, `signature_error`, `unsupported_operation`, and `api_error`
+
+## Hydrate
+
+`xhs hydrate <id_or_url_or_index> --yaml` returns a stable, agent-facing note
+shape without requiring separate `read` and `comments` calls:
+
+```yaml
+ok: true
+schema_version: "1"
+data:
+  note:
+    id: note-id
+    url: https://www.xiaohongshu.com/explore/note-id
+    title: Example
+    body: Note body
+    author: {id: user-id, name: Author}
+    note_type: image
+    liked_count: 0
+    collected_count: 0
+    comment_count: 0
+    share_count: 0
+    tags: []
+    images: []
+    published_at: "2026-07-22T12:00:00Z"
+  comments:
+    - nickname: Commenter
+      content: Example comment
+      like_count: "0"
+      sub_comment_count: 0
+      published_at: "2026-07-22T12:01:00Z"
+  warnings:
+    - code: signature_error
+      message: Signature verification failed
+```
+
+`warnings` is empty when comment retrieval succeeds. A warning means note
+hydration succeeded but the optional comment sample was unavailable.

--- a/SKILL.md
+++ b/SKILL.md
@@ -86,6 +86,7 @@ Payloads live under `.data`.
 |---------|-------------|---------|
 | `xhs search <keyword>` | Search notes | `xhs search "美食" --sort popular --type video` |
 | `xhs read <id_or_url_or_index>` | Read a note by ID, URL, or short index | `xhs read 1` / `xhs read "https://...?xsec_token=xxx"` |
+| `xhs hydrate <id_or_url_or_index>` | Fetch normalized note detail and a bounded comment sample | `xhs hydrate 1 --yaml` |
 | `xhs comments <id_or_url_or_index>` | Get comments by ID, URL, or short index | `xhs comments 1` / `xhs comments "https://...?xsec_token=..."` |
 | `xhs comments <id_or_url> --all` | Get ALL comments (auto-paginate) | `xhs comments "<url>" --all --json` |
 | `xhs sub-comments <note_id> <comment_id>` | Get replies to comment | `xhs sub-comments abc 123` |

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,7 @@ import yaml
 from click.testing import CliRunner
 
 from xhs_cli.cli import cli
-from xhs_cli.exceptions import NoCookieError, SessionExpiredError, UnsupportedOperationError
+from xhs_cli.exceptions import NoCookieError, SessionExpiredError, SignatureError, UnsupportedOperationError
 
 runner = CliRunner()
 
@@ -68,7 +68,7 @@ class TestCliBasic:
             # Auth
             "login", "status", "logout", "whoami",
             # Reading
-            "search", "read", "comments", "sub-comments", "user", "user-posts",
+            "search", "read", "hydrate", "comments", "sub-comments", "user", "user-posts",
             "feed", "hot", "topics", "search-user", "my-notes",
             "notifications", "unread",
             # Interactions
@@ -301,6 +301,79 @@ class TestCliBasic:
         assert called["note_id"] == "note-abc"
         assert called["kwargs"]["xsec_token"] == "token-abc"
         assert called["kwargs"]["xsec_source"] == "pc_search"
+
+    def test_hydrate_returns_stable_note_and_limited_comments(self, monkeypatch):
+        class FakeClient:
+            def get_note_detail(self, note_id, **kwargs):
+                return {
+                    "items": [{
+                        "id": note_id,
+                        "note_card": {
+                            "title": "Test Note",
+                            "desc": "body",
+                            "time": 1_700_000_000_000,
+                            "type": "video",
+                            "user": {"user_id": "u-1", "nickname": "Author"},
+                            "interact_info": {"liked_count": "12", "comment_count": "2"},
+                            "tag_list": [{"name": "AI"}],
+                            "image_list": [{"url_default": "https://example.com/1.jpg"}],
+                        },
+                    }]
+                }
+
+            def get_comments(self, note_id, **kwargs):
+                return {"comments": [
+                    {"user_info": {"nickname": "c1"}, "content": "first", "time": 1_700_000_001},
+                    {"user_info": {"nickname": "c2"}, "content": "second"},
+                ]}
+
+        monkeypatch.setattr(
+            "xhs_cli.commands._common.run_client_action",
+            lambda ctx, action: action(FakeClient()),
+        )
+
+        result = runner.invoke(cli, ["hydrate", "note-123", "--comment-limit", "1", "--yaml"])
+
+        assert result.exit_code == 0
+        payload = yaml.safe_load(result.output)
+        assert payload["data"]["note"] == {
+            "id": "note-123",
+            "url": "https://www.xiaohongshu.com/explore/note-123",
+            "title": "Test Note",
+            "body": "body",
+            "author": {"id": "u-1", "name": "Author"},
+            "note_type": "video",
+            "liked_count": 12,
+            "collected_count": 0,
+            "comment_count": 2,
+            "share_count": 0,
+            "tags": ["AI"],
+            "images": ["https://example.com/1.jpg"],
+            "published_at": "2023-11-14T22:13:20Z",
+        }
+        assert len(payload["data"]["comments"]) == 1
+        assert payload["data"]["comments"][0]["published_at"] == "2023-11-14T22:13:21Z"
+        assert payload["data"]["warnings"] == []
+
+    def test_hydrate_reports_comment_api_failure_as_partial_success(self, monkeypatch):
+        class FakeClient:
+            def get_note_detail(self, note_id, **kwargs):
+                return FAKE_NOTE_RESPONSE
+
+            def get_comments(self, note_id, **kwargs):
+                raise SignatureError()
+
+        monkeypatch.setattr(
+            "xhs_cli.commands._common.run_client_action",
+            lambda ctx, action: action(FakeClient()),
+        )
+
+        result = runner.invoke(cli, ["hydrate", "note-123", "--yaml"])
+
+        assert result.exit_code == 0
+        payload = yaml.safe_load(result.output)
+        assert payload["data"]["comments"] == []
+        assert payload["data"]["warnings"][0]["code"] == "signature_error"
 
     def test_comments_index_resolves_note_context(self, monkeypatch):
         monkeypatch.setattr(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -102,6 +102,23 @@ class TestTransportCookies:
 
 
 class TestReadingEndpointBehavior:
+    def test_get_note_from_html_matches_feed_response_shape(self, monkeypatch):
+        monkeypatch.setattr(XhsClient, "_fetch_note_html", lambda *args, **kwargs: "<html>")
+        monkeypatch.setattr(
+            "xhs_cli.client_mixins.extract_note_from_html",
+            lambda html, note_id: {"title": "HTML note"},
+        )
+
+        client = XhsClient({"a1": "cookie"})
+        try:
+            result = client.get_note_from_html("note-123")
+        finally:
+            client.close()
+
+        assert result == {
+            "items": [{"id": "note-123", "note_card": {"title": "HTML note"}}],
+        }
+
     def test_get_note_detail_prefers_cached_xsec_source(self, monkeypatch):
         captured = {}
 

--- a/xhs_cli/cli.py
+++ b/xhs_cli/cli.py
@@ -4,6 +4,7 @@ Usage:
     xhs login / status / logout
     xhs search <keyword> [--sort popular|latest] [--type video|image] [--page N]
     xhs read <id_or_url> [--xsec-token TOKEN]
+    xhs hydrate <id_or_url> [--comment-limit N]
     xhs comments <id_or_url>
     xhs user <user_id>
     xhs user-posts <user_id> [--cursor CURSOR]
@@ -79,6 +80,7 @@ cli.add_command(auth.whoami)
 
 cli.add_command(reading.search)
 cli.add_command(reading.read)
+cli.add_command(reading.hydrate)
 cli.add_command(reading.comments)
 cli.add_command(reading.sub_comments)
 cli.add_command(reading.user)

--- a/xhs_cli/client_mixins.py
+++ b/xhs_cli/client_mixins.py
@@ -339,7 +339,8 @@ class ReadingEndpointsMixin:
     ) -> dict[str, Any]:
         """Fetch note by parsing server-rendered HTML (no xsec_token required)."""
         html = self._fetch_note_html(note_id, xsec_token=xsec_token, xsec_source=xsec_source)
-        return extract_note_from_html(html, note_id)
+        note = extract_note_from_html(html, note_id)
+        return {"items": [{"id": note_id, "note_card": note}]}
 
     def get_note_detail(
         self,

--- a/xhs_cli/commands/reading.py
+++ b/xhs_cli/commands/reading.py
@@ -4,6 +4,8 @@ import click
 
 from ..command_normalizers import normalize_paged_notes
 from ..cookies import cache_note_context
+from ..error_codes import error_code_for_exception
+from ..exceptions import XhsApiError
 from ..formatter import (
     maybe_print_structured,
     print_info,
@@ -16,6 +18,7 @@ from ..formatter import (
     render_user_posts,
     render_users,
 )
+from ..formatter_normalizers import normalize_comments, normalize_hydrated_note
 from ..note_refs import resolve_note_reference, save_index_from_items, save_index_from_notes
 from ._common import exit_for_error, handle_command, run_client_action, structured_output_options
 
@@ -101,6 +104,61 @@ def read(ctx, id_or_url: str, xsec_token: str, as_json: bool, as_yaml: bool):
         ctx,
         action=_read_action,
         render=render_note,
+        as_json=as_json,
+        as_yaml=as_yaml,
+    )
+
+
+@click.command()
+@click.argument("id_or_url")
+@click.option("--xsec-token", default="", help="Security token (or reuse a cached token for this note)")
+@click.option(
+    "-c", "--comment-limit",
+    type=click.IntRange(min=0),
+    default=5,
+    show_default=True,
+    help="Maximum comments to include (0 skips comments)",
+)
+@structured_output_options
+@click.pass_context
+def hydrate(ctx, id_or_url: str, xsec_token: str, comment_limit: int, as_json: bool, as_yaml: bool):
+    """Fetch normalized note detail and a bounded comment sample."""
+    note_id, token, url_source = resolve_note_reference(id_or_url, xsec_token=xsec_token)
+    xsec_source = url_source or "pc_feed"
+    if token:
+        cache_note_context(note_id, token, xsec_source)
+
+    def _hydrate_action(client):
+        kwargs = {"xsec_token": token}
+        if url_source:
+            kwargs["xsec_source"] = url_source
+        note = normalize_hydrated_note(
+            client.get_note_detail(note_id, **kwargs),
+            note_id=note_id,
+            xsec_token=token,
+            xsec_source=xsec_source,
+        )
+        if note is None:
+            raise XhsApiError(f"Note not found: {note_id}")
+
+        comments = []
+        warnings = []
+        if comment_limit:
+            try:
+                comments = normalize_comments(client.get_comments(note_id, **kwargs))[:comment_limit]
+            except XhsApiError as exc:
+                warnings.append({
+                    "code": error_code_for_exception(exc),
+                    "message": str(exc),
+                })
+        return {"note": note, "comments": comments, "warnings": warnings}
+
+    handle_command(
+        ctx,
+        action=_hydrate_action,
+        render=lambda data: print_info(
+            f"Hydrated {data['note']['id']}: {len(data['comments'])} comments"
+        ),
         as_json=as_json,
         as_yaml=as_yaml,
     )

--- a/xhs_cli/formatter_normalizers.py
+++ b/xhs_cli/formatter_normalizers.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import Any
+from urllib.parse import urlencode
 
 
 def _coerce_int(value: Any, default: int = 0) -> int:
@@ -60,6 +62,81 @@ def normalize_note_detail(data: dict[str, Any]) -> dict[str, Any] | None:
     }
 
 
+def normalize_hydrated_note(
+    data: dict[str, Any],
+    *,
+    note_id: str,
+    xsec_token: str = "",
+    xsec_source: str = "pc_feed",
+) -> dict[str, Any] | None:
+    """Normalize note detail into a stable agent-facing shape."""
+    items = data.get("items", [])
+    if not items or not isinstance(items[0], dict):
+        return None
+
+    entry = items[0]
+    note = entry.get("note_card", {})
+    if not isinstance(note, dict):
+        return None
+    user = note.get("user", {}) if isinstance(note.get("user"), dict) else {}
+    interact = note.get("interact_info", {}) if isinstance(note.get("interact_info"), dict) else {}
+    tags = note.get("tag_list", []) if isinstance(note.get("tag_list"), list) else []
+    images = note.get("image_list", []) if isinstance(note.get("image_list"), list) else []
+    published_at = _published_at(note, entry)
+    token = xsec_token or entry.get("xsec_token") or note.get("xsec_token") or ""
+    token = str(token)
+    url = f"https://www.xiaohongshu.com/explore/{note_id}"
+    if token:
+        url += "?" + urlencode({"xsec_token": token, "xsec_source": xsec_source})
+
+    return {
+        "id": note_id,
+        "url": url,
+        "title": note.get("title") or note.get("display_title") or "Untitled",
+        "body": note.get("desc", ""),
+        "author": {
+            "id": user.get("user_id", ""),
+            "name": user.get("nickname", user.get("nick_name", "Unknown")),
+        },
+        "note_type": "video" if note.get("type") == "video" else "image",
+        "liked_count": _coerce_int(interact.get("liked_count")),
+        "collected_count": _coerce_int(interact.get("collected_count")),
+        "comment_count": _coerce_int(interact.get("comment_count")),
+        "share_count": _coerce_int(interact.get("share_count")),
+        "tags": [tag.get("name", "") for tag in tags if isinstance(tag, dict) and tag.get("name")],
+        "images": [image_url for image in images if (image_url := _image_url(image))],
+        "published_at": published_at,
+    }
+
+
+def _image_url(image: Any) -> str:
+    if not isinstance(image, dict):
+        return ""
+    candidates = [image.get("url_default"), image.get("url_pre"), image.get("url")]
+    info_list = image.get("info_list", [])
+    for info in info_list if isinstance(info_list, list) else []:
+        if isinstance(info, dict):
+            candidates.append(info.get("url"))
+    value = next((str(value).strip() for value in candidates if value), "")
+    if value.startswith("//"):
+        return f"https:{value}"
+    if value.startswith("http://"):
+        return f"https://{value.removeprefix('http://')}"
+    return value
+
+
+def _published_at(*objects: dict[str, Any]) -> str:
+    keys = ("time", "timestamp", "create_time", "ctime")
+    value = next((obj.get(key) for obj in objects for key in keys if obj.get(key)), None)
+    try:
+        timestamp = float(value)
+        while abs(timestamp) > 10_000_000_000:
+            timestamp /= 1000
+        return datetime.fromtimestamp(timestamp, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+    except (TypeError, ValueError, OverflowError, OSError):
+        return ""
+
+
 def normalize_note_summary(item: dict[str, Any]) -> dict[str, Any] | None:
     note_card = item.get("note_card", item)
     if not isinstance(note_card, dict):
@@ -93,6 +170,7 @@ def normalize_comments(data: dict[str, Any]) -> list[dict[str, Any]]:
             "content": comment.get("content", ""),
             "like_count": comment.get("like_count", "0"),
             "sub_comment_count": _coerce_int(comment.get("sub_comment_count", 0)),
+            "published_at": _published_at(comment),
         })
     return normalized
 


### PR DESCRIPTION
## Summary

Add `xhs hydrate <id_or_url_or_index>` for agents that need a normalized note and bounded comment sample in one command.

The command reuses the existing resolver, token cache, client, normalizers, structured-output envelope, and stable error mapping. It adds no dependencies.

## Behavior

- accepts note IDs, URLs, and recent short indexes
- returns normalized text, author, interaction counts, tags, media URLs, and UTC ISO 8601 publish time
- includes up to `--comment-limit` comments; zero skips comments
- reports recoverable comment failures as structured warnings
- URL-encodes `xsec_token` and `xsec_source`
- normalizes the HTML fallback into the same response envelope as the feed API, so direct IDs work without an existing token

The schema and command references are documented in `SCHEMA.md`, `README.md`, and `SKILL.md`.

## Validation

- `uv run ruff check .`
- HTML fallback and hydrate regression tests: 3 passed
- remaining offline suite: 115 passed, 27 skipped, 13 deselected; two pre-existing cache-isolation tests are fixed in PR #76
- `uv build`
- `git diff --check`

## Prior art

The direction was informed by downstream agent-oriented forks, including the stream-curator integration in `Hi-Zi-Li/xiaohongshu-cli`. This is an independent focused implementation on current upstream `main`.