### PR TITLE
fix: avoid replaying non-idempotent account actions

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,7 @@
 """Tests for CLI commands using Click's test runner."""
 
+from contextlib import contextmanager
+
 import pytest
 import yaml
 from click.testing import CliRunner
@@ -157,6 +159,26 @@ class TestCliBasic:
         assert payload["ok"] is False
         assert payload["error"]["code"] == "not_authenticated"
 
+    def test_non_idempotent_action_is_not_replayed(self, monkeypatch):
+        from xhs_cli.commands import _common
+
+        calls = []
+
+        @contextmanager
+        def fake_get_client(ctx, force_refresh=False):
+            yield object()
+
+        def action(_client):
+            calls.append("called")
+            raise SessionExpiredError()
+
+        monkeypatch.setattr(_common, "get_client", fake_get_client)
+
+        with pytest.raises(SessionExpiredError):
+            _common.run_client_action(None, action, retry_on_session_expiry=False)
+
+        assert calls == ["called"]
+
     def test_logout_supports_structured_output(self):
         from xhs_cli.commands import auth
 
@@ -175,7 +197,7 @@ class TestCliBasic:
     def test_delete_reports_unsupported_operation(self, monkeypatch):
         monkeypatch.setattr(
             "xhs_cli.commands.creator.run_client_action",
-            lambda ctx, action: (_ for _ in ()).throw(
+            lambda ctx, action, **kwargs: (_ for _ in ()).throw(
                 UnsupportedOperationError("Delete note is currently unavailable from the public web API.")
             ),
         )
@@ -414,7 +436,8 @@ class TestCliBasic:
 
                 return _call
 
-        def fake_handle_command(ctx, action, render, as_json, as_yaml):
+        def fake_handle_command(ctx, action, render, as_json, as_yaml, retry_on_session_expiry=True):
+            assert retry_on_session_expiry is False
             action(FakeClient())
             return None
 
@@ -443,7 +466,8 @@ class TestCliBasic:
                 called["content"] = content
                 return {"ok": True}
 
-        def fake_handle_command(ctx, action, render, as_json, as_yaml):
+        def fake_handle_command(ctx, action, render, as_json, as_yaml, retry_on_session_expiry=True):
+            assert retry_on_session_expiry is False
             action(FakeClient())
             return None
 
@@ -473,7 +497,8 @@ class TestCliBasic:
                 called["content"] = content
                 return {"ok": True}
 
-        def fake_handle_command(ctx, action, render, as_json, as_yaml):
+        def fake_handle_command(ctx, action, render, as_json, as_yaml, retry_on_session_expiry=True):
+            assert retry_on_session_expiry is False
             action(FakeClient())
             return None
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -101,6 +101,35 @@ class TestTransportCookies:
         assert client.cookies["web_session_sec"] == "real-sec"
 
 
+class TestTransportRetries:
+    @pytest.mark.parametrize(
+        ("method", "expected_attempts"),
+        [("GET", 3), ("PUT", 3), ("POST", 1)],
+    )
+    def test_only_idempotent_methods_retry_network_errors(self, monkeypatch, method, expected_attempts):
+        attempts = 0
+
+        class _FailingHttpClient:
+            def request(self, request_method, url, **kwargs):
+                nonlocal attempts
+                attempts += 1
+                raise httpx.ReadTimeout("response lost", request=httpx.Request(request_method, url))
+
+            def close(self):
+                return None
+
+        monkeypatch.setattr("xhs_cli.client.time.sleep", lambda _seconds: None)
+        client = XhsClient({"a1": "cookie"}, request_delay=0, max_retries=3)
+        client._http = _FailingHttpClient()
+        try:
+            with pytest.raises(XhsApiError, match=rf"after {expected_attempts} attempt"):
+                client._request_with_retry(method, "https://edith.xiaohongshu.com/api/test")
+        finally:
+            client.close()
+
+        assert attempts == expected_attempts
+
+
 class TestReadingEndpointBehavior:
     def test_get_note_detail_prefers_cached_xsec_source(self, monkeypatch):
         captured = {}

--- a/xhs_cli/client.py
+++ b/xhs_cli/client.py
@@ -160,33 +160,39 @@ class XhsClient(
     def _request_with_retry(self, method: str, url: str, **kwargs) -> httpx.Response:
         self._rate_limit_delay()
         last_exc: Exception | None = None
+        idempotent = method.upper() in {"GET", "HEAD", "OPTIONS", "PUT", "DELETE"}
+        attempts = max(1, self._max_retries) if idempotent else 1
 
-        for attempt in range(self._max_retries):
+        for attempt in range(attempts):
             try:
                 resp = self._http.request(method, url, **kwargs)
                 self._merge_response_cookies(resp)
                 self._mark_request()
                 if resp.status_code in (429, 500, 502, 503, 504):
+                    if attempt + 1 == attempts:
+                        break
                     wait = (2 ** attempt) + random.uniform(0, 1)
                     logger.warning(
                         "HTTP %d from %s, retrying in %.1fs (attempt %d/%d)",
-                        resp.status_code, url[:80], wait, attempt + 1, self._max_retries,
+                        resp.status_code, url[:80], wait, attempt + 1, attempts,
                     )
                     time.sleep(wait)
                     continue
                 return resp
             except (httpx.TimeoutException, httpx.NetworkError) as exc:
                 last_exc = exc
+                if attempt + 1 == attempts:
+                    break
                 wait = (2 ** attempt) + random.uniform(0, 1)
                 logger.warning(
                     "Network error: %s, retrying in %.1fs (attempt %d/%d)",
-                    exc, wait, attempt + 1, self._max_retries,
+                    exc, wait, attempt + 1, attempts,
                 )
                 time.sleep(wait)
 
         if last_exc:
-            raise XhsApiError(f"Request failed after {self._max_retries} retries: {last_exc}") from last_exc
-        raise XhsApiError(f"Request failed after {self._max_retries} retries: HTTP {resp.status_code}")
+            raise XhsApiError(f"Request failed after {attempts} attempt(s): {last_exc}") from last_exc
+        raise XhsApiError(f"Request failed after {attempts} attempt(s): HTTP {resp.status_code}")
 
     def _main_api_get(
         self,

--- a/xhs_cli/commands/_common.py
+++ b/xhs_cli/commands/_common.py
@@ -37,12 +37,19 @@ def get_client(ctx, *, force_refresh: bool = False) -> XhsClient:
     return XhsClient(cookies)
 
 
-def run_client_action(ctx, action: Callable[[XhsClient], T]) -> T:
-    """Run an authenticated client action and retry once with fresh browser cookies."""
+def run_client_action(
+    ctx,
+    action: Callable[[XhsClient], T],
+    *,
+    retry_on_session_expiry: bool = True,
+) -> T:
+    """Run an authenticated action, optionally retrying once with fresh cookies."""
     try:
         with get_client(ctx) as client:
             return action(client)
     except SessionExpiredError as exc:
+        if not retry_on_session_expiry:
+            raise
         try:
             with get_client(ctx, force_refresh=True) as client:
                 return action(client)
@@ -58,12 +65,17 @@ def handle_command(
     as_json: bool,
     as_yaml: bool,
     prefix: str | None = None,
+    retry_on_session_expiry: bool = True,
 ):
     """Run a client action, emit structured output if requested, else render."""
     from ..formatter import maybe_print_structured
 
     try:
-        data = run_client_action(ctx, action)
+        data = run_client_action(
+            ctx,
+            action,
+            retry_on_session_expiry=retry_on_session_expiry,
+        )
         if not maybe_print_structured(data, as_json=as_json, as_yaml=as_yaml) and render:
             render(data)
         return data

--- a/xhs_cli/commands/creator.py
+++ b/xhs_cli/commands/creator.py
@@ -81,6 +81,7 @@ def post(
         render=lambda _data: print_success(f"Note published: {title}" + (" (private)" if is_private else "")),
         as_json=as_json,
         as_yaml=as_yaml,
+        retry_on_session_expiry=False,
     )
 
 
@@ -118,7 +119,11 @@ def delete(ctx, id_or_url: str, as_json: bool, as_yaml: bool, yes: bool):
         click.confirm(f"Delete note {note_id}?", abort=True)
 
     try:
-        data = run_client_action(ctx, lambda client: client.delete_note(note_id))
+        data = run_client_action(
+            ctx,
+            lambda client: client.delete_note(note_id),
+            retry_on_session_expiry=False,
+        )
         if not maybe_print_structured(data, as_json=as_json, as_yaml=as_yaml):
             print_success(f"Deleted note {note_id}")
     except Exception as exc:

--- a/xhs_cli/commands/interactions.py
+++ b/xhs_cli/commands/interactions.py
@@ -30,6 +30,7 @@ def like(ctx, id_or_url: str, undo: bool, as_json: bool, as_yaml: bool):
         render=lambda _data: print_success(f"{'Unliked' if undo else 'Liked'} note {note_id}"),
         as_json=as_json,
         as_yaml=as_yaml,
+        retry_on_session_expiry=False,
     )
 
 
@@ -46,6 +47,7 @@ def favorite(ctx, id_or_url: str, as_json: bool, as_yaml: bool):
         render=lambda _data: print_success(f"Favorited note {note_id}"),
         as_json=as_json,
         as_yaml=as_yaml,
+        retry_on_session_expiry=False,
     )
 
 
@@ -62,6 +64,7 @@ def unfavorite(ctx, id_or_url: str, as_json: bool, as_yaml: bool):
         render=lambda _data: print_success(f"Unfavorited note {note_id}"),
         as_json=as_json,
         as_yaml=as_yaml,
+        retry_on_session_expiry=False,
     )
 
 
@@ -79,6 +82,7 @@ def comment(ctx, id_or_url: str, content: str, as_json: bool, as_yaml: bool):
         render=lambda _data: print_success(f"Comment posted on {note_id}"),
         as_json=as_json,
         as_yaml=as_yaml,
+        retry_on_session_expiry=False,
     )
 
 
@@ -97,6 +101,7 @@ def reply(ctx, id_or_url: str, comment_id: str, content: str, as_json: bool, as_
         render=lambda _data: print_success(f"Reply posted on comment {comment_id}"),
         as_json=as_json,
         as_yaml=as_yaml,
+        retry_on_session_expiry=False,
     )
 
 
@@ -117,4 +122,5 @@ def delete_comment(ctx, note_id: str, comment_id: str, as_json: bool, as_yaml: b
         render=lambda _data: print_success(f"Deleted comment {comment_id}"),
         as_json=as_json,
         as_yaml=as_yaml,
+        retry_on_session_expiry=False,
     )

--- a/xhs_cli/commands/social.py
+++ b/xhs_cli/commands/social.py
@@ -60,6 +60,7 @@ def follow(ctx, user_id: str, as_json: bool, as_yaml: bool):
         render=lambda _data: print_success(f"Followed user {user_id}"),
         as_json=as_json,
         as_yaml=as_yaml,
+        retry_on_session_expiry=False,
     )
 
 
@@ -75,6 +76,7 @@ def unfollow(ctx, user_id: str, as_json: bool, as_yaml: bool):
         render=lambda _data: print_success(f"Unfollowed user {user_id}"),
         as_json=as_json,
         as_yaml=as_yaml,
+        retry_on_session_expiry=False,
     )
 
 
@@ -104,4 +106,3 @@ def likes(ctx, user_id: str | None, cursor: str, as_json: bool, as_yaml: bool):
         fetcher=lambda client, uid, cur: client.get_user_likes(uid, cursor=cur),
         user_id=user_id, cursor=cursor, as_json=as_json, as_yaml=as_yaml,
     )
-


### PR DESCRIPTION
## What changed

- retry only idempotent transport methods after network failures or retryable HTTP responses
- keep PUT uploads retryable while sending POST and other mutations once
- disable session-expiry action replay for likes, favorites, comments, replies, follows, publishing, and deletes
- retain automatic cookie refresh and retry for read-only commands

## Root cause

The transport layer retried every HTTP method, and the command layer retried every complete action after a session-expiry response. An ambiguous response could therefore replay a comment, publication, or other account mutation.

## Impact

Automation remains fully available, but account-changing operations are never executed a second time automatically. Callers receive the existing structured error and can decide whether to retry after checking the resulting state.

## Validation

- `uv run ruff check .`
- 116 offline tests passed, 27 skipped, 13 deselected; two pre-existing cache-isolation tests were excluded locally and are fixed separately in PR #76
- targeted retry and mutation tests: 10 passed
- `uv build`
- `git diff --check`